### PR TITLE
Recarrega página ao remover parâmetro de vagas

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -553,18 +553,14 @@
             try { arr = JSON.parse(decodeURIComponent(raw)); } catch (ee) { return; }
           }
           if (!Array.isArray(arr)) return;
-          const { added, updated, skipped } = importFromArray(arr);
+          const { added, updated } = importFromArray(arr);
           if (added || updated) {
             // atualiza tabela imediatamente
             renderTable();
-            // remove o parâmetro da URL para não reimportar em futuros reloads
-            try {
-              const u = new URL(window.location.href);
-              u.searchParams.delete('vagas');
-              history.replaceState(null, '', u.toString());
-            } catch (e) { console.error(e); }
-            // mostra notificação — sem recarregar a página
-            showToast(`Import automático: ${added} adicionada(s), ${updated} atualizada(s), ${skipped} ignorada(s)`);
+            // remove o parâmetro da URL e recarrega a página para não reimportar em futuros reloads
+            const u = new URL(window.location.href);
+            u.searchParams.delete('vagas');
+            window.location.replace(u.toString());
           }
         } catch (err) {
           console.error('Erro importando da URL', err);


### PR DESCRIPTION
## Summary
- Remove o parâmetro `vagas` da URL após importação e recarrega a página usando `window.location.replace`
- Elimina toast redundante e variável não utilizada

## Testing
- `npm test` *(erro: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5a842e2c832e8765e14f831ea2f7