### PR TITLE
Link header title to home

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -55,6 +55,11 @@
       letter-spacing: .4px;
     }
 
+    .header h1 a {
+      color: inherit;
+      text-decoration: none;
+    }
+
     .toolbar {
       display: flex;
       gap: 10px;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>Controle de Vagas</h1>
+      <h1><a href="./">Controle de Vagas</a></h1>
       <div class="toolbar">
         <button id="btnCopyLink" class="btn-secondary" title="Copiar link com os dados">Copiar link</button>
       </div>


### PR DESCRIPTION
## Summary
- Wrap the page header title with a link back to the homepage
- Style the header link to inherit text color and remove underline

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bb5a89cc78832e99003426c41b4f7e