### PR TITLE
refactor: clean import parameter without reload

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -557,17 +557,10 @@
           if (added || updated) {
             // atualiza tabela imediatamente
             renderTable();
-            // remove o parâmetro da URL e recarrega a página para não reimportar em futuros reloads
+            // remove o parâmetro da URL sem recarregar a página
             const u = new URL(window.location.href);
             u.searchParams.delete('vagas');
-            console.log(u.toString())
-            window.location.replace(u.toString());
-
-            const titleEl = document.getElementById('pageTitle');
-            if (titleEl) {
-              const anchor = titleEl.querySelector('a');
-              if (anchor) anchor.click();
-            }
+            history.replaceState(null, '', u.toString());
           }
         } catch (err) {
           console.error('Erro importando da URL', err);


### PR DESCRIPTION
## Summary
- avoid reloading page when removing `vagas` param after import

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb7c91a38832ea20de330c25a6c97