### PR TITLE
Add robots.txt with sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://malgany.github.io/lista-vagas/sitemap.xml


### PR DESCRIPTION
## Summary
- add robots.txt allowing all agents and referencing sitemap URL

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd8ae2a9c832ea742582e3ded61e0