### PR TITLE
Add canonical link to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Gerencie suas candidaturas a vagas de emprego em um só lugar" />
   <meta name="keywords" content="vagas, emprego, controle, candidatura" />
+  <link rel="canonical" href="https://malgany.github.io/lista-vagas/" />
   <title>Controle de Vagas</title>
   <link rel="stylesheet" href="css/style.css" />
   </head>


### PR DESCRIPTION
## Summary
- add canonical link to index.html after meta tags

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bbd936c348832e83d5925586f5a663